### PR TITLE
Assent Gen page and Form navigation

### DIFF
--- a/src/components/CharacterForm.js
+++ b/src/components/CharacterForm.js
@@ -1,7 +1,9 @@
+import GeneratedAsset from "@/components/GeneratedAsset";
 import { useState } from "react";
 
 export default function CharacterForm({ onBack }) {
   const [formData, setFormData] = useState({
+    name: "",
     race: "",
     class: "",
     gender: "",
@@ -15,16 +17,48 @@ export default function CharacterForm({ onBack }) {
     pose: "",
   });
 
+  const [isSubmitted, setIsSubmitted] = useState(false); // Tracks if the form is submitted
+  const [generatedResult, setGeneratedResult] = useState(null); // Placeholder for API response
+  const [loading, setLoading] = useState(false); // Tracks loading state
+  const [error, setError] = useState(null); // Tracks errors
+
   const handleChange = (e) => {
     const { name, value } = e.target;
     setFormData((prev) => ({ ...prev, [name]: value }));
   };
 
-  const handleSubmit = (e) => {
+  const handleSubmit = async (e) => {
     e.preventDefault();
-    console.log("Form submitted:", formData);
-    // Add API call or form submission logic here
+    setLoading(true); // Start loading
+    setError(null); // Clear any previous errors
+
+    try {
+      // Placeholder for API call
+      console.log("Form data submitted:", formData);
+
+      const response = {
+        // API call to generate will go here
+      };
+
+      // Store the response and navigate to GeneratedAsset
+      setGeneratedResult(response);
+      setIsSubmitted(true); // Navigate to GeneratedAsset
+    } catch (err) {
+      setError("An error occurred. Please try again."); // Handle errors
+    } finally {
+      setLoading(false); // Stop loading
+    }
   };
+
+  if (isSubmitted) {
+    // Navigate to GeneratedAsset with the form data and generated result
+    return (
+      <GeneratedAsset
+        onBack={() => setIsSubmitted(false)} // Allow going back to the form
+        data={{ id: "characters", ...formData, generated: generatedResult }}
+      />
+    );
+  }
 
   return (
     <form onSubmit={handleSubmit} className="space-y-8">
@@ -217,8 +251,9 @@ export default function CharacterForm({ onBack }) {
         <button
           type="submit"
           className="px-4 py-2 text-sm font-medium text-white bg-indigo-600 rounded-md hover:bg-indigo-500"
+          disabled={loading} // Disable button while loading
         >
-          Submit
+          {loading ? "Submitting..." : "Submit"}
         </button>
       </div>
     </form>

--- a/src/components/GeneratedAsset.js
+++ b/src/components/GeneratedAsset.js
@@ -1,0 +1,152 @@
+import { useState } from "react";
+
+export default function GeneratedAsset({ onBack, data }) {
+  const placeholderImages = {
+    locations: "/placeholder/card_environment.png",
+    characters: "/placeholder/card_character.png",
+    quests: "/placeholder/card_quest.png",
+    maps: "/placeholder/card_map.png",
+  };
+
+  const assetStory = {
+    locations: "Description",
+    maps: "Backstory",
+    characters: "Backstory",
+    quests: "Story",
+  };
+
+  const imageSrc = placeholderImages[data?.id] || "/placeholder/default.png";
+  const assetStoryTitle = assetStory[data?.id] || "Story";
+  const [visibility, setVisibility] = useState("Public");
+  const [name, setName] = useState(data?.name || "Unnamed");
+  const [isEditing, setIsEditing] = useState(false); // State to track edit mode
+  const [tempName, setTempName] = useState(name); // Temporary name while editing
+
+  const handleVisibilityChange = (option) => {
+    setVisibility(option);
+  };
+
+  const startEditing = () => {
+    setTempName(name); // Set temporary name to the current name
+    setIsEditing(true);
+  };
+
+  const saveName = () => {
+    setName(tempName); // Save the updated name
+    setIsEditing(false); // Exit edit mode
+  };
+
+  const cancelEditing = () => {
+    setIsEditing(false); // Exit edit mode without saving
+  };
+
+  const formattedId = data?.id
+    ? data.id.charAt(0).toUpperCase() + data.id.slice(1).toLowerCase()
+    : "Unknown";
+
+  return (
+    <div className="flex flex-col items-center justify-center min-h-screen">
+      <div className="bg-gray-900 rounded-lg shadow-lg p-5 text-center w-4/5 max-w-4xl">
+        {/* Image Section */}
+        <img
+          src={imageSrc}
+          alt={`${data?.id || "Unknown"} Asset`}
+          className="w-100 h-100 mx-auto rounded-md shadow-2xl"
+        />
+
+        {/* Asset Name Section */}
+        <h4 className="text-2xl font-bold text-white mt-4">
+          Your {formattedId} Name
+        </h4>
+        <div className="flex justify-center items-center mt-4">
+          {isEditing ? (
+            <>
+              <input
+                type="text"
+                value={tempName}
+                onChange={(e) => setTempName(e.target.value)}
+                className="bg-gray-700 text-white rounded-md px-4 py-2 mr-4"
+              />
+              <button
+                onClick={saveName}
+                className="px-4 py-2 bg-green-600 text-white rounded-md hover:bg-green-500"
+              >
+                Save
+              </button>
+              <button
+                onClick={cancelEditing}
+                className="px-4 py-2 bg-red-600 text-white rounded-md hover:bg-red-500 ml-2"
+              >
+                Cancel
+              </button>
+            </>
+          ) : (
+            <>
+              <input
+                type="text"
+                value={name}
+                readOnly
+                className="bg-gray-700 text-white rounded-md px-4 py-2 mr-4"
+              />
+              <button
+                onClick={startEditing}
+                className="px-4 py-2 bg-indigo-600 text-white rounded-md hover:bg-indigo-500"
+              >
+                Change
+              </button>
+            </>
+          )}
+        </div>
+
+        {/* Visibility Toggle Buttons */}
+        <div className="flex justify-center mt-6 space-x-4">
+          <button
+            onClick={() => handleVisibilityChange("Public")}
+            className={`px-4 py-2 rounded-md ${
+              visibility === "Public"
+                ? "bg-gray-400 text-black"
+                : "bg-gray-600 text-white"
+            }`}
+          >
+            Public
+          </button>
+          <button
+            onClick={() => handleVisibilityChange("Private")}
+            className={`px-4 py-2 rounded-md ${
+              visibility === "Private"
+                ? "bg-gray-400 text-black"
+                : "bg-gray-600 text-white"
+            }`}
+          >
+            Private
+          </button>
+        </div>
+        <p className="text-gray-400 mt-4">
+          Current visibility: <span className="text-white">{visibility}</span>
+        </p>
+
+        {/* Backstory Section */}
+        <h4 className="text-2xl font-bold text-white mt-7">
+          <i>{assetStoryTitle}</i>
+        </h4>
+        {data?.generated && Object.keys(data.generated).length > 0 ? (
+          <pre className="text-sm text-gray-500 mt-4 bg-gray-700 p-4 rounded-md">
+            {JSON.stringify(data.generated, null, 2)}
+          </pre>
+        ) : (
+          <p className="text-sm text-gray-400 mt-4">
+            Lorem ipsum dolor sit amet, consectetur adipiscing elit...
+          </p>
+        )}
+
+        {/* Back Button */}
+        <button
+          onClick={onBack}
+          className="mt-6 px-4 py-2 bg-indigo-600 text-white rounded-md hover:bg-indigo-500"
+        >
+          Back
+        </button>
+      </div>
+    </div>
+  );
+}

--- a/src/components/LocationForm.js
+++ b/src/components/LocationForm.js
@@ -1,3 +1,4 @@
+import GeneratedAsset from "@/components/GeneratedAsset"; // NEW
 import { useState } from "react";
 
 export default function LocationForm({ onBack }) {
@@ -13,236 +14,262 @@ export default function LocationForm({ onBack }) {
     lore: "",
   });
 
+  const [isSubmitted, setIsSubmitted] = useState(false); // Tracks if the form is submitted
+  const [generatedResult, setGeneratedResult] = useState(null); // Placeholder for API response
+  const [loading, setLoading] = useState(false); // Tracks loading state
+  const [error, setError] = useState(null); // Tracks errors
+
   const handleChange = (e) => {
     const { name, value } = e.target;
     setFormData((prev) => ({ ...prev, [name]: value }));
   };
 
-  const handleSubmit = (e) => {
+  const handleSubmit = async (e) => {
     e.preventDefault();
-    console.log("Form submitted:", formData);
-    // Add API call or form submission logic here
+    setLoading(true); // Start loading
+    setError(null); // Clear any previous errors
+
+    try {
+      // Placeholder for API call
+      console.log("Form data submitted:", formData);
+
+      const response = {
+        // API call to generate will go here
+      };
+
+      // Store the response and navigate to GeneratedAsset
+      setGeneratedResult(response);
+      setIsSubmitted(true); // Navigate to GeneratedAsset
+    } catch (err) {
+      setError("An error occurred. Please try again."); // Handle errors
+    } finally {
+      setLoading(false); // Stop loading
+    }
   };
+
+  if (isSubmitted) {
+    // Navigate to GeneratedAsset with the form data and generated result
+    return (
+      <GeneratedAsset
+        onBack={() => setIsSubmitted(false)} // Allow going back to the form
+        data={{ id: "locations", ...formData, generated: generatedResult }}
+      />
+    );
+  }
 
   return (
     <form onSubmit={handleSubmit} className="space-y-8">
       <div className="space-y-6">
         <h2 className="text-lg font-semibold text-white">Create Location</h2>
 
-        {/* First Row: Location Name and Type */}
-        <div className="grid grid-cols-1 sm:grid-cols-2 gap-x-4">
-          {/* Location Name */}
-          <div>
-            <label
-              htmlFor="name"
-              className="block text-sm font-medium text-white"
-            >
-              Location Name
-            </label>
-            <input
-              type="text"
-              id="name"
-              name="name"
-              value={formData.name}
-              onChange={handleChange}
-              className="block w-full mt-1 h-12 rounded-md bg-gray-800 border-gray-600 text-white placeholder:text-gray-400 focus:ring-indigo-500 focus:border-indigo-500 sm:text-sm px-3"
-              placeholder="Enter the name of the location"
-            />
-          </div>
+        {/* Display Error Message */}
+        {error && <p className="text-red-500">{error}</p>}
 
-          {/* Type */}
-          <div>
-            <label
-              htmlFor="type"
-              className="block text-sm font-medium text-white"
-            >
-              Type
-            </label>
-            <select
-              id="type"
-              name="type"
-              value={formData.type}
-              onChange={handleChange}
-              className="block w-full mt-1 h-12 rounded-md bg-gray-800 border-gray-600 text-white focus:ring-indigo-500 focus:border-indigo-500 sm:text-sm px-3"
-            >
-              <option value="">Select a type</option>
-              {["placeHolder", "placeHolder", "placeHolder"].map((type) => (
-                <option key={type} value={type}>
-                  {type}
-                </option>
-              ))}
-            </select>
-          </div>
-        </div>
-
-        {/* Second Section: Dropdowns */}
-        <div className="grid grid-cols-1 sm:grid-cols-2 gap-x-4 gap-y-6">
-          {/* Terrain */}
-          <div>
-            <label
-              htmlFor="terrain"
-              className="block text-sm font-medium text-white"
-            >
-              Terrain
-            </label>
-            <select
-              id="terrain"
-              name="terrain"
-              value={formData.terrain}
-              onChange={handleChange}
-              className="block w-full mt-1 h-12 rounded-md bg-gray-800 border-gray-600 text-white focus:ring-indigo-500 focus:border-indigo-500 sm:text-sm px-3"
-            >
-              <option value="">Select a terrain</option>
-              {["placeHolder", "placeHolder", "placeHolder"].map((terrain) => (
-                <option key={terrain} value={terrain}>
-                  {terrain}
-                </option>
-              ))}
-            </select>
-          </div>
-
-          {/* Atmosphere */}
-          <div>
-            <label
-              htmlFor="atmosphere"
-              className="block text-sm font-medium text-white"
-            >
-              Atmosphere
-            </label>
-            <select
-              id="atmosphere"
-              name="atmosphere"
-              value={formData.atmosphere}
-              onChange={handleChange}
-              className="block w-full mt-1 h-12 rounded-md bg-gray-800 border-gray-600 text-white focus:ring-indigo-500 focus:border-indigo-500 sm:text-sm px-3"
-            >
-              <option value="">Select an atmosphere</option>
-              {["placeHolder", "placeHolder", "placeHolder"].map(
-                (atmosphere) => (
-                  <option key={atmosphere} value={atmosphere}>
-                    {atmosphere}
-                  </option>
-                ),
-              )}
-            </select>
-          </div>
-
-          {/* Inhabitants */}
-          <div>
-            <label
-              htmlFor="inhabitants"
-              className="block text-sm font-medium text-white"
-            >
-              Inhabitants
-            </label>
-            <select
-              id="inhabitants"
-              name="inhabitants"
-              value={formData.inhabitants}
-              onChange={handleChange}
-              className="block w-full mt-1 h-12 rounded-md bg-gray-800 border-gray-600 text-white focus:ring-indigo-500 focus:border-indigo-500 sm:text-sm px-3"
-            >
-              <option value="">Select an inhabitants</option>
-              {["placeHolder", "placeHolder", "placeHolder"].map(
-                (inhabitants) => (
-                  <option key={inhabitants} value={inhabitants}>
-                    {inhabitants}
-                  </option>
-                ),
-              )}
-            </select>
-          </div>
-
-          {/* Climate */}
-          <div>
-            <label
-              htmlFor="climate"
-              className="block text-sm font-medium text-white"
-            >
-              Climate
-            </label>
-            <select
-              id="climate"
-              name="climate"
-              value={formData.climate}
-              onChange={handleChange}
-              className="block w-full mt-1 h-12 rounded-md bg-gray-800 border-gray-600 text-white focus:ring-indigo-500 focus:border-indigo-500 sm:text-sm px-3"
-            >
-              <option value="">Select an climate</option>
-              {["placeHolder", "placeHolder", "placeHolder"].map((climate) => (
-                <option key={climate} value={climate}>
-                  {climate}
-                </option>
-              ))}
-            </select>
-          </div>
-
-          {/* danger level */}
-          <div>
-            <label
-              htmlFor="danger level"
-              className="block text-sm font-medium text-white"
-            >
-              Danger Level
-            </label>
-            <select
-              id="dangerLevel"
-              name="dangerLevel"
-              value={formData.dangerLevel}
-              onChange={handleChange}
-              className="block w-full mt-1 h-12 rounded-md bg-gray-800 border-gray-600 text-white focus:ring-indigo-500 focus:border-indigo-500 sm:text-sm px-3"
-            >
-              <option value="">Select an danger level</option>
-              {["placeHolder", "placeHolder", "placeHolder"].map(
-                (dangerLevel) => (
-                  <option key={dangerLevel} value={dangerLevel}>
-                    {dangerLevel}
-                  </option>
-                ),
-              )}
-            </select>
-          </div>
-
-          {/* notable features */}
-          <div>
-            <label
-              htmlFor="notableFeatures"
-              className="block text-sm font-medium text-white"
-            >
-              Notable Features
-            </label>
-            <textarea
-              id="notableFeatures"
-              name="notableFeatures"
-              rows={3}
-              value={formData.notableFeatures}
-              onChange={handleChange}
-              className="block w-full mt-1 h-12 rounded-md bg-gray-800 border-gray-600 text-white placeholder:text-gray-400 focus:ring-indigo-500 focus:border-indigo-500 sm:text-sm px-3"
-              placeholder="Enter notable features here"
-            />
-          </div>
-        </div>
-
-        {/* lore */}
+        {/* Location Name */}
         <div>
           <label
-            htmlFor="lore"
+            htmlFor="name"
             className="block text-sm font-medium text-white"
           >
-            Lore
+            Location Name
           </label>
-          <textarea
-            id="lore"
-            name="lore"
-            rows={3}
-            value={formData.lore}
+          <input
+            type="text"
+            id="name"
+            name="name"
+            value={formData.name}
             onChange={handleChange}
             className="block w-full mt-1 h-12 rounded-md bg-gray-800 border-gray-600 text-white placeholder:text-gray-400 focus:ring-indigo-500 focus:border-indigo-500 sm:text-sm px-3"
-            placeholder="Enter lore here"
+            placeholder="Enter the name of the location"
+          />
+        </div>
+
+        {/* Type */}
+        <div>
+          <label
+            htmlFor="type"
+            className="block text-sm font-medium text-white"
+          >
+            Type
+          </label>
+          <select
+            id="type"
+            name="type"
+            value={formData.type}
+            onChange={handleChange}
+            className="block w-full mt-1 h-12 rounded-md bg-gray-800 border-gray-600 text-white focus:ring-indigo-500 focus:border-indigo-500 sm:text-sm px-3"
+          >
+            <option value="">Select a type</option>
+            {["placeHolder", "placeHolder", "placeHolder"].map((type) => (
+              <option key={type} value={type}>
+                {type}
+              </option>
+            ))}
+          </select>
+        </div>
+      </div>
+
+      {/* Second Section: Dropdowns */}
+      <div className="grid grid-cols-1 sm:grid-cols-2 gap-x-4 gap-y-6">
+        {/* Terrain */}
+        <div>
+          <label
+            htmlFor="terrain"
+            className="block text-sm font-medium text-white"
+          >
+            Terrain
+          </label>
+          <select
+            id="terrain"
+            name="terrain"
+            value={formData.terrain}
+            onChange={handleChange}
+            className="block w-full mt-1 h-12 rounded-md bg-gray-800 border-gray-600 text-white focus:ring-indigo-500 focus:border-indigo-500 sm:text-sm px-3"
+          >
+            <option value="">Select a terrain</option>
+            {["placeHolder", "placeHolder", "placeHolder"].map((terrain) => (
+              <option key={terrain} value={terrain}>
+                {terrain}
+              </option>
+            ))}
+          </select>
+        </div>
+
+        {/* Atmosphere */}
+        <div>
+          <label
+            htmlFor="atmosphere"
+            className="block text-sm font-medium text-white"
+          >
+            Atmosphere
+          </label>
+          <select
+            id="atmosphere"
+            name="atmosphere"
+            value={formData.atmosphere}
+            onChange={handleChange}
+            className="block w-full mt-1 h-12 rounded-md bg-gray-800 border-gray-600 text-white focus:ring-indigo-500 focus:border-indigo-500 sm:text-sm px-3"
+          >
+            <option value="">Select an atmosphere</option>
+            {["placeHolder", "placeHolder", "placeHolder"].map((atmosphere) => (
+              <option key={atmosphere} value={atmosphere}>
+                {atmosphere}
+              </option>
+            ))}
+          </select>
+        </div>
+
+        {/* Inhabitants */}
+        <div>
+          <label
+            htmlFor="inhabitants"
+            className="block text-sm font-medium text-white"
+          >
+            Inhabitants
+          </label>
+          <select
+            id="inhabitants"
+            name="inhabitants"
+            value={formData.inhabitants}
+            onChange={handleChange}
+            className="block w-full mt-1 h-12 rounded-md bg-gray-800 border-gray-600 text-white focus:ring-indigo-500 focus:border-indigo-500 sm:text-sm px-3"
+          >
+            <option value="">Select an inhabitants</option>
+            {["placeHolder", "placeHolder", "placeHolder"].map(
+              (inhabitants) => (
+                <option key={inhabitants} value={inhabitants}>
+                  {inhabitants}
+                </option>
+              ),
+            )}
+          </select>
+        </div>
+
+        {/* Climate */}
+        <div>
+          <label
+            htmlFor="climate"
+            className="block text-sm font-medium text-white"
+          >
+            Climate
+          </label>
+          <select
+            id="climate"
+            name="climate"
+            value={formData.climate}
+            onChange={handleChange}
+            className="block w-full mt-1 h-12 rounded-md bg-gray-800 border-gray-600 text-white focus:ring-indigo-500 focus:border-indigo-500 sm:text-sm px-3"
+          >
+            <option value="">Select an climate</option>
+            {["placeHolder", "placeHolder", "placeHolder"].map((climate) => (
+              <option key={climate} value={climate}>
+                {climate}
+              </option>
+            ))}
+          </select>
+        </div>
+
+        {/* danger level */}
+        <div>
+          <label
+            htmlFor="danger level"
+            className="block text-sm font-medium text-white"
+          >
+            Danger Level
+          </label>
+          <select
+            id="dangerLevel"
+            name="dangerLevel"
+            value={formData.dangerLevel}
+            onChange={handleChange}
+            className="block w-full mt-1 h-12 rounded-md bg-gray-800 border-gray-600 text-white focus:ring-indigo-500 focus:border-indigo-500 sm:text-sm px-3"
+          >
+            <option value="">Select an danger level</option>
+            {["placeHolder", "placeHolder", "placeHolder"].map(
+              (dangerLevel) => (
+                <option key={dangerLevel} value={dangerLevel}>
+                  {dangerLevel}
+                </option>
+              ),
+            )}
+          </select>
+        </div>
+
+        {/* notable features */}
+        <div>
+          <label
+            htmlFor="notableFeatures"
+            className="block text-sm font-medium text-white"
+          >
+            Notable Features
+          </label>
+          <textarea
+            id="notableFeatures"
+            name="notableFeatures"
+            rows={3}
+            value={formData.notableFeatures}
+            onChange={handleChange}
+            className="block w-full mt-1 h-12 rounded-md bg-gray-800 border-gray-600 text-white placeholder:text-gray-400 focus:ring-indigo-500 focus:border-indigo-500 sm:text-sm px-3"
+            placeholder="Enter notable features here"
           />
         </div>
       </div>
 
+      {/* lore */}
+      <div>
+        <label htmlFor="lore" className="block text-sm font-medium text-white">
+          Lore
+        </label>
+        <textarea
+          id="lore"
+          name="lore"
+          rows={3}
+          value={formData.lore}
+          onChange={handleChange}
+          className="block w-full mt-1 h-12 rounded-md bg-gray-800 border-gray-600 text-white placeholder:text-gray-400 focus:ring-indigo-500 focus:border-indigo-500 sm:text-sm px-3"
+          placeholder="Enter lore here"
+        />
+      </div>
       {/* Buttons */}
       <div className="flex justify-end gap-4">
         <button
@@ -255,8 +282,9 @@ export default function LocationForm({ onBack }) {
         <button
           type="submit"
           className="px-4 py-2 text-sm font-medium text-white bg-indigo-600 rounded-md hover:bg-indigo-500"
+          disabled={loading} // Disable button while loading
         >
-          Submit
+          {loading ? "Submitting..." : "Submit"}
         </button>
       </div>
     </form>

--- a/src/components/MapForm.js
+++ b/src/components/MapForm.js
@@ -1,16 +1,24 @@
+import GeneratedAsset from "@/components/GeneratedAsset";
 import { useState } from "react";
 import Select from "react-select";
 
 export default function MapForm({ onBack }) {
+  // Initialize form state with all fields, including a unique ID
   const [formData, setFormData] = useState({
+    name: "",
     type: "",
     class: "",
     style: "",
     scale: "",
-    terrain: [],
+    terrain: [], // Multi-select for terrain options
     orientation: "",
     poi: "",
   });
+
+  const [isSubmitted, setIsSubmitted] = useState(false);
+  const [generatedResult, setGeneratedResult] = useState(null); // Placeholder for API response
+  const [loading, setLoading] = useState(false);
+  const [error, setError] = useState(null);
 
   // Options for the Terrain Multi-Select
   const options = [
@@ -76,13 +84,11 @@ export default function MapForm({ onBack }) {
     }),
   };
 
-  // Handle change for regular inputs
   const handleChange = (e) => {
     const { name, value } = e.target;
     setFormData((prev) => ({ ...prev, [name]: value }));
   };
 
-  // Handle change for React-Select
   const handleTerrainChange = (selectedOptions) => {
     setFormData((prev) => ({
       ...prev,
@@ -92,19 +98,62 @@ export default function MapForm({ onBack }) {
     }));
   };
 
-  const handleSubmit = (e) => {
+  const handleSubmit = async (e) => {
     e.preventDefault();
-    console.log("Form submitted:", formData);
-    // Add API call or form submission logic here
+    setLoading(true);
+    setError(null);
+
+    try {
+      console.log("Form data submitted:", formData);
+
+      const response = {
+        // Simulated API response (replace with actual API call)
+      };
+
+      setGeneratedResult(response);
+      setIsSubmitted(true);
+    } catch (err) {
+      setError("An error occurred. Please try again.");
+    } finally {
+      setLoading(false);
+    }
   };
+
+  if (isSubmitted) {
+    return (
+      <GeneratedAsset
+        onBack={() => setIsSubmitted(false)}
+        data={{ id: "maps", ...formData, generated: generatedResult }}
+      />
+    );
+  }
 
   return (
     <form onSubmit={handleSubmit} className="space-y-8">
       <div className="space-y-6">
         <h2 className="text-lg font-semibold text-white">Create Map</h2>
+        {error && <p className="text-red-500 text-center">{error}</p>}
 
-        {/* Dropdowns */}
         <div className="grid grid-cols-1 gap-y-6 sm:grid-cols-2 gap-x-4">
+          {/* Map Name */}
+          <div>
+            <label
+              htmlFor="name"
+              className="block text-sm font-medium text-white"
+            >
+              Map Name
+            </label>
+            <input
+              type="text"
+              id="name"
+              name="name"
+              value={formData.name}
+              onChange={handleChange}
+              className="block w-full mt-1 h-12 rounded-md bg-gray-800 border-gray-600 text-white placeholder:text-gray-400 focus:ring-indigo-500 focus:border-indigo-500 sm:text-sm px-3"
+              placeholder="Enter a name for the map"
+            />
+          </div>
+
           {/* Type */}
           <div>
             <label
@@ -118,10 +167,10 @@ export default function MapForm({ onBack }) {
               name="type"
               value={formData.type}
               onChange={handleChange}
-              className="block w-full mt-1 h-12 rounded-md bg-gray-800 border-gray-600 text-white placeholder:text-gray-400 placeholder:pt-2 placeholder:pl-3 focus:ring-indigo-500 focus:border-indigo-500 sm:text-sm px-3"
+              className="block w-full mt-1 h-12 rounded-md bg-gray-800 border-gray-600 text-white placeholder:text-gray-400 focus:ring-indigo-500 focus:border-indigo-500 sm:text-sm px-3"
             >
               <option value="">Select a type</option>
-              {["PlaceHolder", "PlaceHolder", "PlaceHolder"].map((type) => (
+              {["PlaceHolder1", "PlaceHolder2", "PlaceHolder3"].map((type) => (
                 <option key={type} value={type}>
                   {type}
                 </option>
@@ -142,10 +191,10 @@ export default function MapForm({ onBack }) {
               name="style"
               value={formData.style}
               onChange={handleChange}
-              className="block w-full mt-1 h-12 rounded-md bg-gray-800 border-gray-600 text-white placeholder:text-gray-400 placeholder:pt-2 placeholder:pl-3 focus:ring-indigo-500 focus:border-indigo-500 sm:text-sm px-3"
+              className="block w-full mt-1 h-12 rounded-md bg-gray-800 border-gray-600 text-white placeholder:text-gray-400 focus:ring-indigo-500 focus:border-indigo-500 sm:text-sm px-3"
             >
               <option value="">Select a style</option>
-              {["PlaceHolder", "PlaceHolder", "PlaceHolder"].map((style) => (
+              {["PlaceHolder1", "PlaceHolder2", "PlaceHolder3"].map((style) => (
                 <option key={style} value={style}>
                   {style}
                 </option>
@@ -166,10 +215,10 @@ export default function MapForm({ onBack }) {
               name="scale"
               value={formData.scale}
               onChange={handleChange}
-              className="block w-full mt-1 h-12 rounded-md bg-gray-800 border-gray-600 text-white placeholder:text-gray-400 placeholder:pt-2 placeholder:pl-3 focus:ring-indigo-500 focus:border-indigo-500 sm:text-sm px-3"
+              className="block w-full mt-1 h-12 rounded-md bg-gray-800 border-gray-600 text-white placeholder:text-gray-400 focus:ring-indigo-500 focus:border-indigo-500 sm:text-sm px-3"
             >
               <option value="">Select a scale</option>
-              {["PlaceHolder", "PlaceHolder", "PlaceHolder"].map((scale) => (
+              {["PlaceHolder1", "PlaceHolder2", "PlaceHolder3"].map((scale) => (
                 <option key={scale} value={scale}>
                   {scale}
                 </option>
@@ -177,7 +226,7 @@ export default function MapForm({ onBack }) {
             </select>
           </div>
 
-          {/* Terrain (React-Select Multi-Select) */}
+          {/* Terrain (Multi-Select) */}
           <div>
             <label
               htmlFor="terrain"
@@ -197,22 +246,24 @@ export default function MapForm({ onBack }) {
               placeholder="Select terrains"
             />
           </div>
-        </div>
-
-        {/* POI */}
-        <div>
-          <label htmlFor="poi" className="block text-sm font-medium text-white">
-            POI
-          </label>
-          <textarea
-            id="poi"
-            name="poi"
-            rows={3}
-            value={formData.poi}
-            onChange={handleChange}
-            className="block w-full mt-1 rounded-md bg-gray-800 border-gray-600 text-white placeholder:text-gray-400 focus:ring-indigo-500 focus:border-indigo-500 sm:text-sm"
-            placeholder="Enter POI here"
-          />
+          {/* POI */}
+          <div>
+            <label
+              htmlFor="poi"
+              className="block text-sm font-medium text-white"
+            >
+              POI
+            </label>
+            <textarea
+              id="poi"
+              name="poi"
+              rows={3}
+              value={formData.poi}
+              onChange={handleChange}
+              className="block w-full mt-1 rounded-md bg-gray-800 border-gray-600 text-white placeholder:text-gray-400 focus:ring-indigo-500 focus:border-indigo-500 sm:text-sm"
+              placeholder="Enter POI here"
+            />
+          </div>
         </div>
       </div>
 
@@ -228,8 +279,9 @@ export default function MapForm({ onBack }) {
         <button
           type="submit"
           className="px-4 py-2 text-sm font-medium text-white bg-indigo-600 rounded-md hover:bg-indigo-500"
+          disabled={loading}
         >
-          Submit
+          {loading ? "Submitting..." : "Submit"}
         </button>
       </div>
     </form>

--- a/src/components/QuestForm.js
+++ b/src/components/QuestForm.js
@@ -1,9 +1,10 @@
+import GeneratedAsset from "@/components/GeneratedAsset";
 import { useState } from "react";
 import Select from "react-select";
 
 export default function QuestForm({ onBack }) {
   const [formData, setFormData] = useState({
-    title: "",
+    name: "", // Quest name
     type: [],
     objective: "",
     combatEncounters: "",
@@ -16,6 +17,11 @@ export default function QuestForm({ onBack }) {
     motivation: "",
     consequences: "",
   });
+
+  const [isSubmitted, setIsSubmitted] = useState(false);
+  const [generatedResult, setGeneratedResult] = useState(null); // Placeholder for API response
+  const [loading, setLoading] = useState(false);
+  const [error, setError] = useState(null);
 
   // Options for the Type Multi-Select
   const options = [
@@ -81,54 +87,76 @@ export default function QuestForm({ onBack }) {
     }),
   };
 
-  // Handle change for regular inputs
   const handleChange = (e) => {
     const { name, value } = e.target;
     setFormData((prev) => ({ ...prev, [name]: value }));
   };
 
-  // Handle change for React-Select
-  const handleTypeChange = (selectedOptions) => {
+  const handleTerrainChange = (selectedOptions) => {
     setFormData((prev) => ({
       ...prev,
-      type: selectedOptions
+      terrain: selectedOptions
         ? selectedOptions.map((option) => option.value)
         : [],
     }));
   };
 
-  const handleSubmit = (e) => {
+  const handleSubmit = async (e) => {
     e.preventDefault();
-    console.log("Form submitted:", formData);
+    setLoading(true);
+    setError(null);
+
+    try {
+      console.log("Form data submitted:", formData);
+
+      const response = {
+        // Simulated API response (replace with actual API call)
+      };
+
+      setGeneratedResult(response);
+      setIsSubmitted(true);
+    } catch (err) {
+      setError("An error occurred. Please try again.");
+    } finally {
+      setLoading(false);
+    }
   };
+
+  if (isSubmitted) {
+    return (
+      <GeneratedAsset
+        onBack={() => setIsSubmitted(false)}
+        data={{ id: "quests", ...formData, generated: generatedResult }}
+      />
+    );
+  }
 
   return (
     <form onSubmit={handleSubmit} className="space-y-8">
       <div className="space-y-6">
         <h2 className="text-lg font-semibold text-white">Create Quests</h2>
 
-        {/* First Row: Title and Type */}
+        {/* name and Type fields */}
         <div className="grid grid-cols-1 sm:grid-cols-2 gap-x-4">
-          {/* Title */}
           <div>
             <label
-              htmlFor="title"
+              htmlFor="name"
               className="block text-sm font-medium text-white"
             >
-              Quest Title
+              Quest name
             </label>
             <input
               type="text"
-              id="title"
-              name="title"
-              value={formData.title}
+              id="name"
+              name="name"
+              value={formData.name}
               onChange={handleChange}
               className="block w-full mt-1 h-12 rounded-md bg-gray-800 border-gray-600 text-white placeholder:text-gray-400 focus:ring-indigo-500 focus:border-indigo-500 sm:text-sm px-3"
-              placeholder="Enter the title of the quest"
+              placeholder="Enter the name of the quest"
             />
           </div>
 
-          {/* Type (React-Select Multi-Select) */}
+          {/* Type Multi-Select */}
           <div>
             <label
               htmlFor="type"
@@ -143,15 +171,15 @@ export default function QuestForm({ onBack }) {
               value={options.filter((option) =>
                 formData.type.includes(option.value),
               )}
-              onChange={handleTypeChange}
+              onChange={handleTerrainChange}
               styles={customStyles}
               placeholder="Select quest type(s)"
             />
           </div>
         </div>
-        {/* Second Row: Objective and Combat Encounters */}
+
+        {/* Objective and Combat Encounters */}
         <div className="grid grid-cols-1 sm:grid-cols-2 gap-x-4">
-          {/* Objective */}
           <div>
             <label
               htmlFor="objective"
@@ -170,7 +198,6 @@ export default function QuestForm({ onBack }) {
             />
           </div>
 
-          {/* Combat Encounters */}
           <div>
             <label
               htmlFor="combatEncounters"
@@ -196,28 +223,9 @@ export default function QuestForm({ onBack }) {
             </select>
           </div>
         </div>
-        {/* Third Row: Location and Combat QuestGiver */}
-        <div className="grid grid-cols-1 sm:grid-cols-2 gap-x-4">
-          {/* Location */}
-          <div>
-            <label
-              htmlFor="location"
-              className="block text-sm font-medium text-white"
-            >
-              Location
-            </label>
-            <input
-              type="text"
-              id="location"
-              name="location"
-              value={formData.location}
-              onChange={handleChange}
-              className="block w-full mt-1 h-12 rounded-md bg-gray-800 border-gray-600 text-white placeholder:text-gray-400 focus:ring-indigo-500 focus:border-indigo-500 sm:text-sm px-3"
-              placeholder="Enter the location of the quest"
-            />
-          </div>
 
-          {/* Quest Giver */}
+        {/* Quest Giver, Rewards, Tone */}
+        <div className="grid grid-cols-1 sm:grid-cols-2 gap-x-4">
           <div>
             <label
               htmlFor="questGiver"
@@ -232,14 +240,10 @@ export default function QuestForm({ onBack }) {
               value={formData.questGiver}
               onChange={handleChange}
               className="block w-full mt-1 h-12 rounded-md bg-gray-800 border-gray-600 text-white placeholder:text-gray-400 focus:ring-indigo-500 focus:border-indigo-500 sm:text-sm px-3"
-              placeholder="Enter the Quest Giver of the quest"
+              placeholder="Enter the quest giver"
             />
           </div>
-        </div>
 
-        {/* Forth Row: Rewards and Tone */}
-        <div className="grid grid-cols-1 sm:grid-cols-2 gap-x-4">
-          {/* Rewards */}
           <div>
             <label
               htmlFor="rewards"
@@ -257,35 +261,10 @@ export default function QuestForm({ onBack }) {
               placeholder="Enter the rewards for the quest"
             />
           </div>
-
-          {/* Tone */}
-          <div>
-            <label
-              htmlFor="tone"
-              className="block text-sm font-medium text-white"
-            >
-              Tone
-            </label>
-            <select
-              id="tone"
-              name="tone"
-              value={formData.tone}
-              onChange={handleChange}
-              className="block w-full mt-1 h-12 rounded-md bg-gray-800 border-gray-600 text-white placeholder:text-gray-400 focus:ring-indigo-500 focus:border-indigo-500 sm:text-sm px-3"
-            >
-              <option value="">Select the Tone</option>
-              {["PlaceHolder1", "PlaceHolder2", "PlaceHolder3"].map((tone) => (
-                <option key={tone} value={tone}>
-                  {tone}
-                </option>
-              ))}
-            </select>
-          </div>
         </div>
 
-        {/* Fifth Row: Duration and Obstacles */}
+        {/* Duration and Obstacles */}
         <div className="grid grid-cols-1 sm:grid-cols-2 gap-x-4">
-          {/* Duration */}
           <div>
             <label
               htmlFor="duration"
@@ -301,15 +280,16 @@ export default function QuestForm({ onBack }) {
               className="block w-full mt-1 h-12 rounded-md bg-gray-800 border-gray-600 text-white placeholder:text-gray-400 focus:ring-indigo-500 focus:border-indigo-500 sm:text-sm px-3"
             >
               <option value="">Select the duration</option>
-              {["PlaceHolder1", "PlaceHolder2", "PlaceHolder3"].map((tone) => (
-                <option key={tone} value={tone}>
-                  {tone}
-                </option>
-              ))}
+              {["PlaceHolder1", "PlaceHolder2", "PlaceHolder3"].map(
+                (duration) => (
+                  <option key={duration} value={duration}>
+                    {duration}
+                  </option>
+                ),
+              )}
             </select>
           </div>
 
-          {/* Obstacles */}
           <div>
             <label
               htmlFor="obstacles"
@@ -329,7 +309,6 @@ export default function QuestForm({ onBack }) {
           </div>
         </div>
 
-        {/* antagonistAndEnemies, motivation, consequences */}
         {/* Antagonist and Enemies */}
         <div>
           <label
@@ -349,6 +328,7 @@ export default function QuestForm({ onBack }) {
           />
         </div>
 
+        {/* Motivation and Consequences */}
         {["motivation", "consequences"].map((field) => (
           <div key={field}>
             <label

--- a/src/pages/create/index.js
+++ b/src/pages/create/index.js
@@ -1,5 +1,5 @@
 import CharacterForm from "@/components/CharacterForm";
-import EnvironmentsForm from "@/components/LocationForm";
+import LocationsForm from "@/components/LocationForm";
 import MapForm from "@/components/MapForm";
 import OptionCard from "@/components/OptionCard";
 import QuestForm from "@/components/QuestForm";
@@ -13,9 +13,9 @@ const options = [
     image: "/placeholder/card_character.png",
   },
   {
-    id: "environments",
-    title: "Environments",
-    description: "Create breathtaking environments for your story.",
+    id: "locations",
+    title: "Locations",
+    description: "Create breathtaking locations for your story.",
     image: "/placeholder/card_environment.png",
   },
   {
@@ -48,9 +48,9 @@ export default function CreatePage() {
       {/* characters */}
       {selectedOption === "characters" ? (
         <CharacterForm onBack={handleGoBack} />
-      ) : /* environments */
-      selectedOption === "environments" ? (
-        <EnvironmentsForm onBack={handleGoBack} />
+      ) : /* locations */
+      selectedOption === "locations" ? (
+        <LocationsForm onBack={handleGoBack} />
       ) : /* maps */
       selectedOption === "maps" ? (
         <MapForm onBack={handleGoBack} />


### PR DESCRIPTION
**Reference to Related Issue**

Fixes [55](https://github.com/tabletop-generator/ttg-client/issues/55)
Fixes [42](https://github.com/tabletop-generator/ttg-client/issues/42)
Fixes [43](https://github.com/tabletop-generator/ttg-client/issues/43)
Fixes [56](https://github.com/tabletop-generator/ttg-client/issues/56)
Fixes [43](https://github.com/tabletop-generator/ttg-client/issues/43)

**Proposed Changes**

- [ ] Generating an asset component page
  - Default img is used based on which form was submitted
  - Text based background is adjusted based on the the type of asset (character-backstory, location-description etc.)
  - Added name field (not input) to all forms to keep consistency, if no name is provided the asset will be displayed as "unnamed" 
  - The user can change the name in the page itself (as per SRS mockups)
  - User can toggle between public / private
  - Back button to return to the previous page
- [ ] Changed quest "title" field to "name" to keep consistency for code and db 
- [ ] Added navigation functionality from each form to be submitted to the generate asset page. Currently no active API available therefore the asset gen page displays placeholder images per form request
- [ ] The text field (Story/backstory/etc) currently displays lorem ipsum to see how it looks like. After APIs available commented line to be used "story unavailable"  for any possible errors and lorem ipsum to be deleted. 

