### PR TITLE
fixed redirection of protected urls without authontication

### DIFF
--- a/src/components/Layout.js
+++ b/src/components/Layout.js
@@ -9,14 +9,43 @@ import {
 } from "@headlessui/react";
 import { Bars3Icon, BellIcon, XMarkIcon } from "@heroicons/react/24/outline";
 import { useRouter } from "next/router";
+import { useEffect, useState } from "react";
 import { useAuth } from "react-oidc-context";
 
 export default function Layout({ children }) {
   const auth = useAuth();
   const router = useRouter();
+
+  const [isReady, setIsReady] = useState(false); //State to handle loading
+
   const classNames = (...classes) => {
     return classes.filter(Boolean).join(" ");
   };
+
+  //our protected routes
+  const protectedRoutePrefixes = ["/create", "/profile"];
+
+  useEffect(() => {
+    if (!auth.isLoading) {
+      //checking to see if any routes protected
+      const isProtected = protectedRoutePrefixes.some((prefix) =>
+        router.pathname.startsWith(prefix),
+      );
+      if (isProtected && !auth.isAuthenticated) {
+        router.push(process.env.NEXT_PUBLIC_OAUTH_SIGN_IN_REDIRECT_URL);
+      } else {
+        setIsReady(true);
+      }
+    }
+  }, [auth.isAuthenticated, auth.isLoading, router.pathname]);
+
+  if (!isReady) {
+    return (
+      <div className="flex items-center justify-center min-h-screen bg-black">
+        <div className="animate-spin rounded-full h-12 w-12 border-t-4 border-b-4 border-white"></div>
+      </div>
+    );
+  }
 
   const handleSignOut = () => {
     const signOutUrl = () => {


### PR DESCRIPTION
**Prevent unauthenticated users from accessing protected routes**

Fixes [#84](https://github.com/tabletop-generator/ttg-client/issues/84)

**Proposed Changes**

- [ ] Added route protection for `/create` and `/profile` paths.
- [ ] Redirect unauthenticated users to the login page when attempting to access protected URLs.

