### PR TITLE
Hash email and send user verification request on login

### DIFF
--- a/src/utils/hashedEmail.js
+++ b/src/utils/hashedEmail.js
@@ -1,0 +1,26 @@
+/**
+ * hashEmail.js - Utility function to hash an email address using SHA-256.
+ *
+ * This function is used to securely hash email addresses before storing or sending them.
+ * Hashing ensures that sensitive data remains protected and non-reversible.
+ *
+ * - Uses the SubtleCrypto API to perform SHA-256 hashing.
+ * - Encodes the email into a Uint8Array before hashing.
+ * - Converts the hash result into a hexadecimal string.
+ *
+ * Usage:
+ *   import { hashEmail } from "@/utils/hashedEmail";
+ *   const hashed = await hashEmail("user@example.com");
+ *
+ * @param {string} email - The email address to be hashed.
+ * @returns {Promise<string>} - A SHA-256 hashed representation of the email in hexadecimal format.
+ */
+
+export async function hashEmail(email) {
+  const encoder = new TextEncoder();
+  const data = encoder.encode(email);
+  const hashBuffer = await crypto.subtle.digest("SHA-256", data);
+  return Array.from(new Uint8Array(hashBuffer))
+    .map((b) => b.toString(16).padStart(2, "0"))
+    .join("");
+}

--- a/src/utils/postNewUser.js
+++ b/src/utils/postNewUser.js
@@ -1,0 +1,46 @@
+/**
+ * postNewUser.js - Utility function to send an empty POST request.
+ *
+ * This file is placed inside the `utils/` directory because:
+ * - It is NOT a React component, so it should not be inside `pages/`.
+ * - It is NOT an API route, so it should not be inside `pages/api/`.
+ *
+ * Usage:
+ *   import { postUser } from "@/utils/postNewUser";
+ *
+ * This function sends a POST request to create a new user in cognitoAuthConfig.js.
+ */
+
+const logger = require("@/utils/logger");
+
+const API_URL = process.env.NEXT_PUBLIC_API_URL || "http://localhost:8080";
+
+export async function postUser(user) {
+  try {
+    //send empty post request
+    const response = await fetch(`${API_URL}/v1/users`, {
+      method: "POST",
+      headers: {
+        Authorization: `Bearer ${user.id_token}`, // Use the ID token
+        "Content-Type": "application/json",
+      },
+      body: JSON.stringify({
+        hashedEmail: user.hashedEmail,
+      }),
+    });
+
+    if (!response.ok) {
+      const errorDetails = await response.text();
+      console.error(
+        `API call failed with status: ${response.status}, Details: ${errorDetails}`,
+      );
+      throw new Error(`API call failed with status: ${response.status}`);
+    }
+
+    const data = await response.json();
+    return { status: response.status, data };
+  } catch (error) {
+    console.error("Error during postUser call:", error);
+    throw error;
+  }
+}


### PR DESCRIPTION
**Reference to Related Issue**

Fixes # [#101 ](https://github.com/tabletop-generator/ttg-client/issues/101)

**Proposed Changes**

- [ ]  Added functionality to hash the user's email upon login using Cognito.
- [ ]   Implemented an empty POST request to the backend (/v1/users/:userId) with the ID token and hashed email..
- [ ]  Updated onSigninCallback to handle this flow seamlessly during user login.

