### PR TITLE
Add Asset to Collection Gallery UI and Update Card UI to Match Mockups

### DIFF
--- a/src/components/Profile/AssetDetailsCard.js
+++ b/src/components/Profile/AssetDetailsCard.js
@@ -1,57 +1,105 @@
 import { deletePrismaAsset, updatePrismaAssetInfo } from "@/api";
-import { Edit, Heart, Trash } from "lucide-react";
-import { useState } from "react";
+import CommentsSection from "@/components/Profile/CommentsSection";
+import CreateCollectionForm from "@/components/Profile/CreateCollectionForm";
+import styles from "@/styles/AssetDetailsCard.module.css"; // The CSS module
+import { Heart, MoreHorizontal, Share2, Star } from "lucide-react";
+import { useEffect, useRef, useState } from "react";
 import { useAuth } from "react-oidc-context";
 
 export default function AssetDetailsCard({ asset, onBack }) {
   const auth = useAuth();
   const user = auth.user;
-  const [likes, setLikes] = useState(asset?.likes || 0); // Fake likes
 
+  // Core asset states
   const [visibility, setVisibility] = useState(asset?.visibility || "private");
-
   const [name, setName] = useState(asset?.name || "Unnamed");
   const [description, setDescription] = useState(
     asset?.description || "No backstory available.",
   );
+
+  // UI states
   const [isEditing, setIsEditing] = useState(false);
+  const [menuOpen, setMenuOpen] = useState(false);
 
-  const defaultImage = "/placeholder/p01.png"; // Fallback image
+  // Likes & like toggle (local for now)
+  const [likes, setLikes] = useState(asset?.likes || 0);
+  const [isLiked, setIsLiked] = useState(false);
 
-  const handleLike = () => setLikes(likes + 1);
+  // Share tooltip
+  const [copied, setCopied] = useState(false);
 
-  const handleDelete = async () => {
-    if (confirm("Are you sure you want to delete this asset?")) {
-      try {
-        await deletePrismaAsset(asset.id);
-        onBack(); // Navigate back after deletion
-        setTimeout(() => {
-          window.location.reload();
-        }, 100);
-        console.log("Asset deleted successfully!");
-      } catch (error) {
-        console.error("Failed to delete asset:", error);
-      }
-    }
+  // Delete modal
+  const [showDeleteModal, setShowDeleteModal] = useState(false);
+
+  const defaultImage = "/placeholder/p01.png"; // fallback
+
+  //collections
+  const [userCollections, setUserCollections] = useState([]);
+  const [isCreatingCollection, setIsCreatingCollection] = useState(false);
+  const [isStarred, setIsStarred] = useState(false);
+  const [showCollectionDropdown, setShowCollectionDropdown] = useState(false);
+
+  const collectionsDropdownRef = useRef(null);
+  const starButtonRef = useRef(null);
+
+  // ---- Handlers ----
+  const handleShare = () => {
+    navigator.clipboard
+      .writeText(window.location.href)
+      .then(() => {
+        setCopied(true);
+        setTimeout(() => setCopied(false), 2000);
+      })
+      .catch((err) => console.error("Failed to copy:", err));
   };
 
+  const handleStar = () => {
+    setIsStarred(!isStarred);
+    setShowCollectionDropdown(true);
+  };
+
+  useEffect(() => {
+    const handleClickOutside = (event) => {
+      if (
+        collectionsDropdownRef.current &&
+        !collectionsDropdownRef.current.contains(event.target) &&
+        starButtonRef.current &&
+        !starButtonRef.current.contains(event.target)
+      ) {
+        setShowCollectionDropdown(false);
+        setIsStarred(false); // Reset star color
+      }
+    };
+
+    document.addEventListener("mousedown", handleClickOutside);
+    return () => document.removeEventListener("mousedown", handleClickOutside);
+  }, []);
+  const handleAddToCollection = (collection) => {
+    console.log(`Added ${asset.name} to collection: ${collection.name}`);
+    setShowCollectionDropdown(false);
+  };
+
+  const handleCreateCollection = (newCollection) => {
+    setUserCollections([...userCollections, newCollection]);
+    setIsCreatingCollection(false);
+    setShowCollectionDropdown(false);
+  };
+  const handleLike = () => {
+    setIsLiked(!isLiked);
+    setLikes((prev) => (!isLiked ? prev + 1 : Math.max(prev - 1, 0)));
+  };
+
+  // Toggle between public/private
   const handleToggleVisibility = (newVisibility) => {
     setVisibility(newVisibility);
-    console.log("Visibility set to:", newVisibility);
+    console.log("Visibility:", newVisibility);
   };
 
   const handleSave = async () => {
-    const newInfo = {
-      name,
-      description,
-      visibility,
-    };
-
-    console.log("New info being sent to API:", newInfo);
-
+    const newInfo = { name, description, visibility };
+    console.log("Saving asset with info:", newInfo);
     try {
       await updatePrismaAssetInfo(user, asset.uuid, newInfo);
-      console.log("Asset updated successfully!");
       asset.visibility = visibility;
       setIsEditing(false);
     } catch (error) {
@@ -66,9 +114,48 @@ export default function AssetDetailsCard({ asset, onBack }) {
     setIsEditing(false);
   };
 
+  // Trigger the delete modal
+  const handleDeleteClick = () => {
+    setShowDeleteModal(true);
+  };
+
+  // Confirm delete
+  const handleDeleteConfirm = async () => {
+    try {
+      await deletePrismaAsset(asset.id);
+      onBack();
+      setTimeout(() => {
+        window.location.reload();
+      }, 100);
+      console.log("Asset deleted successfully!");
+    } catch (error) {
+      console.error("Failed to delete asset:", error);
+    }
+    setShowDeleteModal(false);
+  };
+
+  // Cancel delete
+  const handleDeleteCancel = () => {
+    setShowDeleteModal(false);
+  };
+
+  // For the 3-dot edit menu
+  const dropdownRef = useRef(null);
+  useEffect(() => {
+    const handleClickOutside = (event) => {
+      if (dropdownRef.current && !dropdownRef.current.contains(event.target)) {
+        setMenuOpen(false);
+      }
+    };
+    document.addEventListener("mousedown", handleClickOutside);
+    return () => document.removeEventListener("mousedown", handleClickOutside);
+  }, []);
+
+  // ---- UI ----
   return (
-    <div className="flex items-center justify-center min-h-screen bg-gray-900 text-white">
-      <div className="bg-gray-800 rounded-lg shadow-lg p-6 w-4/5 max-w-2xl">
+    <div className={styles.assetCardContainer}>
+      <div className={styles.assetCard}>
+        {/* ASSET IMAGE */}
         {/* eslint-disable-next-line @next/next/no-img-element */}
         <img
           src={asset.imageUrl || defaultImage}
@@ -76,40 +163,26 @@ export default function AssetDetailsCard({ asset, onBack }) {
           className="w-full rounded-lg mb-6"
         />
 
-        <div className="flex items-center justify-between mb-6">
+        {/* ASSET NAME + LIKE COUNT */}
+        <div className="flex items-center justify-between mb-4">
           {isEditing ? (
             <input
               type="text"
               value={name}
               onChange={(e) => setName(e.target.value)}
-              className="text-3xl font-bold text-black p-2 rounded w-2/3"
+              className="text-2xl font-bold text-black p-2 rounded w-2/3"
               placeholder="Enter Asset Name"
             />
           ) : (
-            <h1 className="text-3xl font-bold text-white">{name}</h1>
+            <h1 className="text-2xl font-bold text-white">{name}</h1>
           )}
-
-          <div className="flex items-center gap-4">
-            <button
-              onClick={handleLike}
-              className="flex items-center text-red-500 hover:opacity-80"
-            >
-              <Heart className="w-5 h-5 mr-1" />
-              <span>{likes}</span>
-            </button>
-
-            {!isEditing && (
-              <button
-                onClick={() => setIsEditing(true)}
-                className="flex items-center text-yellow-400 hover:text-yellow-300"
-              >
-                <Edit className="w-5 h-5 mr-1" />
-                Edit
-              </button>
-            )}
+          <div className="flex items-center text-red-500 ml-2">
+            <Heart className="w-5 h-5 mr-1 fill-current" />
+            <span className="text-white">{likes}</span>
           </div>
         </div>
 
+        {/* Asset type area*/}
         <p className="text-gray-400 mb-2 capitalize">
           <strong>Type:</strong> {asset.type || "Unknown Type"}
         </p>
@@ -120,8 +193,136 @@ export default function AssetDetailsCard({ asset, onBack }) {
             : "N/A"}
         </p>
 
-        <h2 className="text-2xl font-bold text-white mb-4">Backstory</h2>
+        {/* BUTTON AREA: Like, Star, Share, Edit */}
+        <div className="flex items-center justify-center gap-4 mb-6">
+          {/* Like button */}
+          {!isEditing && (
+            <button
+              onClick={handleLike}
+              className={`${styles.roundedButton} w-10 h-10 hover:opacity-80 ${
+                isLiked ? "bg-red-500 text-white" : "bg-gray-700 text-gray-300"
+              }`}
+            >
+              <Heart className="w-5 h-5" fill="currentColor" />
+            </button>
+          )}
 
+          {/* Star Button & Collection Dropdown */}
+          {!isEditing && (
+            <div className="relative" ref={collectionsDropdownRef}>
+              <button
+                ref={starButtonRef} // Reference the button
+                onClick={handleStar}
+                className={`w-10 h-10 ${styles.roundedButton} ${
+                  isStarred ? "bg-yellow-500 text-black" : styles.bgGrayButton
+                }`}
+              >
+                <Star className="w-5 h-5 fill-current" />
+              </button>
+
+              {/* Collection Dropdown */}
+              {!isEditing && showCollectionDropdown && (
+                <div className="absolute top-12 left-1/2 -translate-x-1/2 bg-gray-900 text-white rounded-md shadow-lg w-48 p-2 z-20">
+                  {userCollections.length > 0 ? (
+                    userCollections.map((collection) => (
+                      <button
+                        key={collection.id}
+                        onClick={() => handleAddToCollection(collection)}
+                        className="block w-full text-left px-4 py-2 hover:bg-gray-700"
+                      >
+                        {collection.name}
+                      </button>
+                    ))
+                  ) : (
+                    <div className="text-center text-gray-400 py-2">
+                      <p>No Collections found</p>
+                      <button
+                        onClick={() => setIsCreatingCollection(true)}
+                        className="mt-2 px-3 py-1 bg-indigo-600 text-white rounded-md hover:bg-indigo-500"
+                      >
+                        Create Collection
+                      </button>
+                    </div>
+                  )}
+                </div>
+              )}
+
+              {/* Render `CreateCollectionForm` outside the small dropdown */}
+              {!isEditing && isCreatingCollection && (
+                <div className="fixed inset-0 flex justify-center items-center bg-black bg-opacity-50 backdrop-blur-md z-50">
+                  <div className="w-96 bg-gray-900 p-6 rounded-lg shadow-lg">
+                    <CreateCollectionForm
+                      onCancel={() => setIsCreatingCollection(false)}
+                      onCreate={handleCreateCollection}
+                    />
+                  </div>
+                </div>
+              )}
+            </div>
+          )}
+
+          {/* Share button + tooltip */}
+          {!isEditing && (
+            <div className="relative">
+              <button
+                onClick={handleShare}
+                className={`w-10 h-10 ${styles.roundedButton} ${
+                  copied ? styles.bgGreenButton : styles.bgGrayButton
+                }`}
+              >
+                <Share2 className="w-5 h-5 text-white fill-current" />
+              </button>
+              {copied && (
+                <div className="absolute bottom-full mb-2 left-1/2 -translate-x-1/2 transform px-3 py-1 bg-white text-black text-sm rounded shadow-lg z-10 whitespace-nowrap">
+                  Copied to Clipboard!
+                  <div
+                    className="absolute bottom-0 left-1/2 transform translate-y-full -translate-x-1/2 w-0 h-0
+                      border-l-[6px] border-l-transparent
+                      border-r-[6px] border-r-transparent
+                      border-t-[6px] border-t-white"
+                  ></div>
+                </div>
+              )}
+            </div>
+          )}
+
+          {/* 3-dot edit button + dropdown */}
+          {!isEditing && (
+            <div className="relative" ref={dropdownRef}>
+              <button
+                onClick={() => setMenuOpen(!menuOpen)}
+                className={`w-10 h-10 ${styles.roundedButton} ${styles.bgGrayButton}`}
+              >
+                <MoreHorizontal className="w-5 h-5 text-white" />
+              </button>
+              {menuOpen && (
+                <div className={styles.dropdownMenu}>
+                  <button
+                    onClick={() => {
+                      setIsEditing(true);
+                      setMenuOpen(false);
+                    }}
+                    className="w-full text-left px-4 py-2 hover:bg-green-700 text-white"
+                  >
+                    Edit
+                  </button>
+                  <button
+                    onClick={() => {
+                      setMenuOpen(false);
+                      setShowDeleteModal(true);
+                    }}
+                    className="w-full text-left text-red-500 px-4 py-2 hover:bg-red-700 hover:text-white"
+                  >
+                    Delete
+                  </button>
+                </div>
+              )}
+            </div>
+          )}
+        </div>
+
+        {/* BACKSTORY */}
+        <h2 className="text-xl font-bold text-white mb-2">Backstory</h2>
         {isEditing ? (
           <textarea
             value={description}
@@ -131,73 +332,142 @@ export default function AssetDetailsCard({ asset, onBack }) {
             placeholder="Enter Backstory"
           />
         ) : (
-          <p className="text-gray-300 leading-relaxed mb-6">{description}</p>
+          <p className="text-gray-300 leading-relaxed mb-4">{description}</p>
         )}
 
+        {/* VISIBILITY SLIDER: only if editing */}
         {isEditing && (
-          <div className="flex justify-center mt-6 space-x-4">
-            <button
-              onClick={() => handleToggleVisibility("public")}
-              className={`px-4 py-2 rounded-md ${
-                visibility === "public"
-                  ? "bg-gray-400 text-black"
-                  : "bg-gray-600 text-white"
-              }`}
-            >
-              Public
-            </button>
-            <button
-              onClick={() => handleToggleVisibility("private")}
-              className={`px-4 py-2 rounded-md ${
-                visibility === "private"
-                  ? "bg-gray-400 text-black"
-                  : "bg-gray-600 text-white"
-              }`}
-            >
-              Private
-            </button>
+          <div className="flex items-center justify-center mb-4">
+            <VisibilitySlider
+              visibility={visibility}
+              onToggle={handleToggleVisibility}
+            />
           </div>
         )}
 
+        {/* Current Visibility (if not editing) */}
         {!isEditing && (
-          <p className="text-gray-400 mt-4">
-            Current visibility:{" "}
-            <span className="text-white">
-              {visibility.charAt(0).toUpperCase() + visibility.slice(1)}
-            </span>
+          <p className="text-gray-400 mb-4">
+            <strong>Visibility:</strong>{" "}
+            <span className="text-white capitalize">{visibility}</span>
           </p>
         )}
 
+        {/* Comments Section (Only show when not editing) */}
+        {!isEditing && <CommentsSection commentCount={13} />}
+
+        {/* SAVE / CANCEL(edit mode) */}
         {isEditing && (
-          <div className="flex justify-center mt-6 space-x-4">
+          <div className="flex items-center justify-center gap-4 mt-4">
             <button
               onClick={handleSave}
-              className="px-4 py-2 bg-green-500 text-white rounded hover:bg-green-400"
+              className="px-4 py-2 bg-green-600 text-white rounded-md hover:bg-green-500"
             >
               Save
             </button>
             <button
               onClick={handleCancel}
-              className="px-4 py-2 bg-gray-600 text-white rounded hover:bg-gray-500"
+              className="px-4 py-2 bg-gray-500 text-white rounded-md hover:bg-gray-400"
             >
               Cancel
-            </button>
-            <button
-              onClick={handleDelete}
-              className="px-4 py-2 bg-red-500 text-white rounded hover:bg-red-400"
-            >
-              <Trash className="w-5 h-5 mr-1" />
-              Delete
             </button>
           </div>
         )}
 
-        <button
-          onClick={onBack}
-          className="mt-6 px-4 py-2 bg-indigo-600 text-white rounded-md hover:bg-indigo-500"
-        >
-          Back
-        </button>
+        {/* Back button */}
+        {!isEditing && (
+          <button
+            onClick={onBack}
+            className="mt-6 px-4 py-2 bg-indigo-600 text-white rounded-md hover:bg-indigo-500"
+          >
+            Back
+          </button>
+        )}
+      </div>
+
+      {/* Delete confirmation modal */}
+      {showDeleteModal && (
+        <DeleteModal
+          assetName={asset.name}
+          onConfirm={handleDeleteConfirm}
+          onCancel={handleDeleteCancel}
+        />
+      )}
+    </div>
+  );
+}
+
+/* 
+  1) VisibilitySlider: a pill-shaped slider with "Public" & "Private".
+  2) DeleteModal: a popup confirmation with custom text & buttons.
+*/
+
+// 1) VisibilitySlider component
+function VisibilitySlider({ visibility, onToggle }) {
+  const isPublic = visibility === "public";
+
+  // Toggle logic on label click
+  const handleClick = (val) => {
+    onToggle(val);
+  };
+
+  return (
+    <div className="relative w-36 h-10 bg-gray-700 rounded-full flex items-center px-2 cursor-pointer select-none">
+      {/* "Public" label */}
+      <span
+        onClick={() => handleClick("public")}
+        className={`z-10 w-1/2 text-center text-sm transition-colors duration-200 ${
+          isPublic ? "text-black" : "text-gray-400"
+        }`}
+      >
+        Public
+      </span>
+
+      {/* "Private" label */}
+      <span
+        onClick={() => handleClick("private")}
+        className={`z-10 w-1/2 text-center text-sm transition-colors duration-200 ${
+          !isPublic ? "text-black" : "text-gray-400"
+        }`}
+      >
+        Private
+      </span>
+
+      {/* Sliding background highlight */}
+      <div
+        className={`absolute top-1 bottom-1 left-1 w-1/2 bg-white rounded-full shadow transform transition-transform duration-300 ${
+          !isPublic ? "translate-x-16" : "translate-x-0"
+        }`}
+      ></div>
+    </div>
+  );
+}
+
+// 2) DeleteModal component
+function DeleteModal({ assetName, onConfirm, onCancel }) {
+  return (
+    <div className="fixed inset-0 bg-black bg-opacity-50 flex items-center justify-center z-50">
+      {/* Modal box */}
+      <div className="bg-white text-black rounded-md p-6 w-80 text-center">
+        <h2 className="text-xl font-bold mb-2">
+          Are you sure you want to delete <br />
+          <span className="text-red-600">{assetName}</span>?
+        </h2>
+        <p className="mb-4">This action can’t be undone!</p>
+        <div className="flex justify-center gap-4">
+          <button
+            onClick={onConfirm}
+            className="px-4 font-bold py-2 bg-red-600 text-white rounded-md hover:bg-red-500"
+          >
+            DELETE
+          </button>
+          <button
+            onClick={onCancel}
+            className="px-4 py-2 font-bold bg-gray-300 text-black rounded-md hover:bg-gray-400"
+          >
+            GO BACK
+          </button>
+        </div>
       </div>
     </div>
   );

--- a/src/components/Profile/CollectionDetails.js
+++ b/src/components/Profile/CollectionDetails.js
@@ -1,26 +1,217 @@
+import { MoreHorizontal, Plus, Share2 } from "lucide-react";
+import { useRouter } from "next/router";
+import { useEffect, useRef, useState } from "react";
+
 export default function CollectionDetails({
   collection,
   onBack,
   onAssetClick,
+  allAssets,
 }) {
+  const router = useRouter();
+  const [showAssetGrid, setShowAssetGrid] = useState(false);
+  const [updatedAssets, setUpdatedAssets] = useState([]);
+  const [menuOpen, setMenuOpen] = useState(false);
+  const [copied, setCopied] = useState(false);
+  const dropdownRef = useRef(null);
+
+  // Get the first asset image OR use a placeholder
+  const backgroundImageUrl =
+    collection.assets?.[0]?.imageUrl || "/placeholder/p02.png";
+
+  // Initialize assets when the collection loads
+  useEffect(() => {
+    setUpdatedAssets(collection.assets || []);
+  }, [collection.assets]);
+
+  // Handle adding an asset (ensure proper ID)
+  const handleAddAsset = (asset) => {
+    if (!asset.id && !asset.uuid) {
+      console.error("Asset is missing an ID or UUID:", asset);
+      return;
+    }
+
+    setUpdatedAssets((prevAssets) => {
+      if (!prevAssets.some((a) => a.id === asset.id || a.uuid === asset.uuid)) {
+        return [...prevAssets, asset];
+      }
+      return prevAssets;
+    });
+
+    setShowAssetGrid(false); // Close asset grid after selection
+  };
+
+  // Navigate to asset details page
+  const handleAssetClick = (asset) => {
+    const assetId = asset.uuid || asset.id;
+    if (!assetId) {
+      console.log("I am just a friendly placeholder");
+      return;
+    }
+    console.log("Navigating to asset:", assetId);
+    router.push(`/profile/${assetId}`);
+  };
+
+  // Close dropdown when clicking outside
+  useEffect(() => {
+    const handleClickOutside = (event) => {
+      if (dropdownRef.current && !dropdownRef.current.contains(event.target)) {
+        setMenuOpen(false);
+      }
+    };
+    document.addEventListener("mousedown", handleClickOutside);
+    return () => document.removeEventListener("mousedown", handleClickOutside);
+  }, []);
+
+  // Handle Share (Copy Link)
+  const handleShare = () => {
+    navigator.clipboard
+      .writeText(window.location.href)
+      .then(() => {
+        setCopied(true);
+        setTimeout(() => setCopied(false), 2000);
+      })
+      .catch((err) => console.error("Failed to copy:", err));
+  };
+
   return (
     <div>
-      <button
-        onClick={onBack}
-        className="px-4 py-2 bg-indigo-600 text-white rounded-md hover:bg-indigo-500 mb-4"
+      {/* Collection Banner - Uses First Asset as Background */}
+      <div
+        className="relative w-full h-40 bg-cover bg-center rounded-lg flex items-center justify-center text-white text-2xl font-bold"
+        style={{
+          backgroundImage: `url(${backgroundImageUrl})`,
+        }}
       >
-        Back to Collections
-      </button>
-      <div className="grid grid-cols-1 sm:grid-cols-2 md:grid-cols-3 gap-4">
-        {collection.assets.map((asset) => (
-          <div
-            key={asset.id}
-            className="bg-gray-800 rounded-lg p-4 text-center"
-            onClick={() => onAssetClick(asset.id)}
+        <div className="absolute inset-0 bg-black bg-opacity-50 rounded-lg"></div>
+        <span className="relative z-10">{collection.name}</span>
+      </div>
+
+      {/* Top Section */}
+      <div className="mt-4 mb-6 flex items-center justify-between">
+        {/* Back Button */}
+        <button
+          onClick={onBack}
+          className="px-4 py-2 bg-indigo-600 text-white rounded-md hover:bg-indigo-500"
+        >
+          Back to Collections
+        </button>
+
+        {/* Right Buttons */}
+        <div className="flex gap-3">
+          {/* Add Asset Button (Round with Plus Icon) */}
+          <button
+            onClick={() => setShowAssetGrid(true)}
+            className="w-10 h-10 bg-gray-700 text-white rounded-full flex items-center justify-center hover:bg-gray-600"
           >
+            <Plus size={20} />
+          </button>
+
+          {/* Share Collection Button*/}
+          <div className="relative">
+            <button
+              onClick={handleShare}
+              className={`w-10 h-10 text-white rounded-full flex items-center justify-center transition-colors duration-300 ${
+                copied
+                  ? "bg-green-500 hover:bg-green-400"
+                  : "bg-gray-700 hover:bg-gray-600"
+              }`}
+            >
+              <Share2 size={20} />
+            </button>
+            {copied && (
+              <div className="absolute bottom-full mb-2 left-1/2 -translate-x-1/2 transform px-3 py-1 bg-white text-black text-sm rounded shadow-lg z-10 whitespace-nowrap">
+                Copied to Clipboard!
+                <div
+                  className="absolute bottom-0 left-1/2 transform translate-y-full -translate-x-1/2 w-0 h-0
+          border-l-[6px] border-l-transparent
+          border-r-[6px] border-r-transparent
+          border-t-[6px] border-t-white"
+                ></div>
+              </div>
+            )}
+          </div>
+
+          {/* More Options Button*/}
+          <div className="relative" ref={dropdownRef}>
+            <button
+              onClick={() => setMenuOpen(!menuOpen)}
+              className="w-10 h-10 bg-gray-700 text-white rounded-full flex items-center justify-center hover:bg-gray-600"
+            >
+              <MoreHorizontal size={20} />
+            </button>
+
+            {/* Dropdown Menu */}
+            {menuOpen && (
+              <div className="absolute right-0 mt-2 bg-gray-800 text-white rounded-md shadow-lg w-32">
+                <button
+                  className="block w-full text-left px-4 py-2 hover:bg-gray-700"
+                  onClick={() => console.log("Edit Collection")}
+                >
+                  Edit
+                </button>
+                <button
+                  className="block w-full text-left px-4 py-2 text-red-400 hover:bg-gray-700"
+                  onClick={() => console.log("Delete Collection")}
+                >
+                  Delete
+                </button>
+              </div>
+            )}
+          </div>
+        </div>
+      </div>
+
+      {/* Show Asset Selection Grid */}
+      {showAssetGrid && (
+        <div className="bg-gray-900 p-4 rounded-lg shadow-lg">
+          <div className="flex justify-between items-center mb-4">
+            <h3 className="text-lg font-bold text-white">
+              Select an Asset to Add
+            </h3>
+            <button
+              onClick={() => setShowAssetGrid(false)}
+              className="px-3 py-1 bg-gray-600 text-white rounded-md hover:bg-gray-500"
+            >
+              Cancel
+            </button>
+          </div>
+
+          {/* Asset Grid */}
+          <div className="grid grid-cols-1 sm:grid-cols-2 md:grid-cols-3 gap-4">
+            {allAssets.map((asset) => (
+              <div
+                key={asset.id || asset.uuid}
+                className="bg-gray-800 rounded-lg p-4 text-center cursor-pointer hover:bg-gray-700"
+                onClick={() => handleAddAsset(asset)}
+              >
+                {" "}
+                {/* eslint-disable-next-line @next/next/no-img-element */}
+                <img
+                  src={asset.imageUrl}
+                  alt={asset.name}
+                  className="w-full aspect-square object-cover rounded-md mb-2"
+                />
+                <h5 className="text-lg font-bold text-white">{asset.name}</h5>
+                <p className="text-gray-400 capitalize">{asset.type}</p>
+              </div>
+            ))}
+          </div>
+        </div>
+      )}
+
+      {/* Collection Assets Grid */}
+      <div className="grid grid-cols-1 sm:grid-cols-2 md:grid-cols-3 gap-4 mt-4">
+        {updatedAssets.map((asset, index) => (
+          <div
+            key={asset.id || asset.uuid || `fallback-key-${index}`}
+            className="bg-gray-800 rounded-lg p-4 text-center cursor-pointer hover:bg-gray-700"
+            onClick={() => handleAssetClick(asset)}
+          >
+            {" "}
             {/* eslint-disable-next-line @next/next/no-img-element */}
             <img
-              src={asset.image}
+              src={asset.imageUrl}
               alt={asset.name}
               className="w-full aspect-square object-cover rounded-md mb-4"
             />

--- a/src/components/Profile/CollectionGrid.js
+++ b/src/components/Profile/CollectionGrid.js
@@ -1,38 +1,68 @@
-export default function CollectionGrid({
-  collections,
-  onCollectionClick,
-  onCreateCollection,
-}) {
+import CreateCollectionForm from "@/components/Profile/CreateCollectionForm";
+import { useState } from "react";
+
+export default function CollectionGrid({ collections, onCollectionClick }) {
+  // Fake default collection
+  const defaultFakeCollection = [
+    {
+      id: "fake-1234",
+      name: "The Chamber of Secrets",
+      visibility: "public",
+      assets: [
+        {
+          assetId: "1234",
+          name: "The Magnificent Dwarf",
+          imageUrl: "/placeholder/p03.png",
+        },
+      ], // Placeholder image
+    },
+  ];
+
+  // Ensure at least one collection exists
+  const [isCreating, setIsCreating] = useState(false);
+  const [fakeCollections, setFakeCollections] = useState(
+    collections.length > 0 ? collections : defaultFakeCollection,
+  );
+
+  const handleCreateCollection = (newCollection) => {
+    setFakeCollections([...fakeCollections, newCollection]); // Add new collection
+    setIsCreating(false); // Hide form after creation
+  };
+
   return (
     <div>
       {/* Create Collection Button */}
-      <div className="mb-4">
-        <button
-          onClick={onCreateCollection}
-          className="px-4 py-2 bg-green-600 text-white rounded-md hover:bg-green-500 shadow-md"
-        >
-          Create Collection
-        </button>
-      </div>
-
-      {/* Conditional Rendering for Collections */}
-      {collections.length === 0 ? (
-        <div className="text-gray-500 text-center">
-          Be creative! Unleash the collector in you and start your first
-          collection today!
+      {!isCreating && (
+        <div className="mb-4">
+          <button
+            onClick={() => setIsCreating(true)}
+            className="px-4 py-2 bg-green-600 text-white rounded-md hover:bg-green-500 shadow-md"
+          >
+            Create Collection
+          </button>
         </div>
+      )}
+
+      {/* Show Create Collection Form */}
+      {isCreating ? (
+        <CreateCollectionForm
+          onCancel={() => setIsCreating(false)}
+          onCreate={handleCreateCollection}
+        />
       ) : (
-        <div className="grid grid-cols-1 sm:grid-cols-2 gap-4">
-          {collections.map((collection) => (
+        <div className="flex flex-col gap-4">
+          {fakeCollections.map((collection) => (
             <button
               key={collection.id}
               onClick={() => onCollectionClick(collection)}
-              className="relative bg-cover bg-center rounded-lg text-white text-xl font-bold p-4 h-32 flex items-center justify-center hover:opacity-90 shadow-lg"
+              className="relative w-full h-40 bg-cover bg-center rounded-lg text-white text-xl font-bold flex items-center justify-center hover:opacity-90 shadow-lg"
               style={{
-                backgroundImage: `url(${collection.assets[0]?.image || "/placeholder/default.png"})`,
+                backgroundImage: `url(${collection.assets[0]?.imageUrl || "/placeholder/p03.png"})`,
               }}
             >
-              {collection.name}
+              {/* Overlay for readability */}
+              <div className="absolute inset-0 bg-black bg-opacity-40 rounded-lg"></div>
+              <span className="relative z-10">{collection.name}</span>
             </button>
           ))}
         </div>

--- a/src/components/Profile/CommentsSection.js
+++ b/src/components/Profile/CommentsSection.js
@@ -1,0 +1,72 @@
+import { MessageSquare } from "lucide-react";
+import { useState } from "react";
+
+export default function CommentsSection({ commentCount = 0 }) {
+  const [isOpen, setIsOpen] = useState(false);
+  const [commentText, setCommentText] = useState("");
+
+  const toggleComments = () => {
+    setIsOpen(!isOpen);
+  };
+
+  return (
+    <div className="mt-4">
+      {/* View Comments Button */}
+      <button
+        onClick={toggleComments}
+        className="w-full py-2 bg-gray-800 text-white text-sm font-medium rounded-lg flex items-center justify-center gap-2"
+      >
+        <MessageSquare className="w-4 h-4" />
+        View {commentCount} Comments
+      </button>
+
+      {/* Comment Section */}
+      {isOpen && (
+        <div className="mt-4 bg-gray-900 p-4 rounded-lg">
+          {/* Placeholder Comment Input */}
+          <div className="flex items-center gap-2 mb-4">
+            <input
+              type="text"
+              value={commentText}
+              onChange={(e) => setCommentText(e.target.value)}
+              className="flex-grow p-2 text-black rounded-md"
+              placeholder="Add a comment..."
+              disabled
+            />
+            <button
+              className="px-4 py-2 bg-blue-600 text-white rounded-md"
+              disabled
+            >
+              Post
+            </button>
+          </div>
+
+          {/* Placeholder Comments */}
+          <div className="space-y-3">
+            <div className="flex items-start gap-3">
+              <div className="w-8 h-8 bg-gray-700 rounded-full"></div>
+              <div>
+                <p className="text-white font-semibold">Skunkley</p>
+                <p className="text-gray-400 text-sm">
+                  AI really said, Trust me, I got this, and honestly… Im
+                  impressed. 😂🔥
+                </p>
+              </div>
+            </div>
+
+            <div className="flex items-start gap-3">
+              <div className="w-8 h-8 bg-gray-700 rounded-full"></div>
+              <div>
+                <p className="text-white font-semibold">Cyan</p>
+                <p className="text-gray-400 text-sm">
+                  This is what happens when AI reads my mind… and adds extra
+                  drama. 🤖🎭😂
+                </p>
+              </div>
+            </div>
+          </div>
+        </div>
+      )}
+    </div>
+  );
+}

--- a/src/components/Profile/CreateCollectionForm.js
+++ b/src/components/Profile/CreateCollectionForm.js
@@ -1,0 +1,103 @@
+import { useState } from "react";
+
+export default function CreateCollectionForm({ onCancel, onCreate }) {
+  const [name, setName] = useState("");
+  const [visibility, setVisibility] = useState("private"); // Default to private
+
+  // Toggle visibility between public and private
+  const handleToggleVisibility = () => {
+    setVisibility((prev) => (prev === "public" ? "private" : "public"));
+  };
+
+  const handleCreate = () => {
+    // Fake collection object
+    const newCollection = {
+      id: Date.now(), // Unique ID (mocked)
+      name,
+      visibility,
+      assets: [], // Empty assets list
+    };
+
+    // Call the parent function with the new collection
+    onCreate(newCollection);
+
+    // Reset fields (optional)
+    setName("");
+    setVisibility("private");
+  };
+
+  return (
+    <div className="bg-gray-800 p-6 rounded-lg shadow-lg">
+      <h2 className="text-xl font-bold text-white mb-4">Create Collection</h2>
+
+      {/* Collection Name Input */}
+      <input
+        type="text"
+        placeholder="Collection Name"
+        value={name}
+        onChange={(e) => setName(e.target.value)}
+        className="w-full p-2 mb-4 text-black rounded-md"
+      />
+
+      {/* Visibility Toggle */}
+      <div className="flex flex-col items-center justify-center mb-5">
+        {/* Centered Label */}
+        <span className="text-white mb-2 text-sm font-medium">Visibility</span>
+
+        {/* Toggle Button */}
+        <div
+          className="relative w-40 h-12 bg-gray-700 rounded-full flex cursor-pointer select-none"
+          onClick={handleToggleVisibility}
+        >
+          {/* Sliding background highlight */}
+          <div
+            className={`absolute inset-y-1 left-1 w-[50%] bg-white rounded-full shadow transition-transform duration-300 ${
+              visibility === "private"
+                ? "translate-x-[calc(100%-6px)]"
+                : "translate-x-0"
+            }`}
+          ></div>
+
+          {/* Public label */}
+          <span
+            className={`absolute left-5 top-1/2 -translate-y-1/2 text-base font-medium transition-colors duration-200 ${
+              visibility === "public" ? "text-black" : "text-gray-300"
+            }`}
+          >
+            Public
+          </span>
+
+          {/* Private label */}
+          <span
+            className={`absolute right-5 top-1/2 -translate-y-1/2 text-base font-medium transition-colors duration-200 ${
+              visibility === "private" ? "text-black" : "text-gray-300"
+            }`}
+          >
+            Private
+          </span>
+        </div>
+      </div>
+
+      {/* Button*/}
+      <div className="flex justify-center gap-4 mt-4">
+        <button
+          onClick={onCancel}
+          className="px-4 py-2 bg-gray-500 text-white rounded-md hover:bg-gray-400"
+        >
+          Cancel
+        </button>
+        <button
+          onClick={handleCreate}
+          disabled={!name.trim()} // Disable if name is empty
+          className={`px-4 py-2 rounded-md ${
+            name.trim()
+              ? "bg-green-600 hover:bg-green-500 text-white"
+              : "bg-gray-600 text-gray-400"
+          }`}
+        >
+          Create
+        </button>
+      </div>
+    </div>
+  );
+}

--- a/src/pages/profile/index.js
+++ b/src/pages/profile/index.js
@@ -175,6 +175,7 @@ function Profile() {
             collection={selectedCollection}
             onBack={() => setSelectedCollection(null)}
             onAssetClick={handleAssetClick}
+            allAssets={userAssets}
           />
         )}
       </div>

--- a/src/styles/AssetDetailsCard.module.css
+++ b/src/styles/AssetDetailsCard.module.css
@@ -1,0 +1,36 @@
+/* Centers the card on the screen, dark background */
+.assetCardContainer {
+  @apply flex items-center justify-center min-h-screen bg-gray-900 text-white;
+}
+
+/* Main card styling: background, rounding, shadow, padding */
+.assetCard {
+  @apply bg-gray-800 rounded-lg shadow-lg p-6 w-4/5 max-w-2xl;
+}
+
+/* Simple media query: reduce padding on small screens */
+@media (max-width: 640px) {
+  .assetCard {
+    @apply p-4;
+  }
+}
+
+/* Common style for round icon buttons (like, star, share, edit) */
+.roundedButton {
+  @apply w-10 h-10 flex items-center justify-center rounded-full;
+}
+
+/* Gray background for round buttons */
+.bgGrayButton {
+  @apply bg-gray-700 hover:bg-gray-600;
+}
+
+/* Green background for share button when copied */
+.bgGreenButton {
+  @apply bg-green-500 hover:bg-green-600;
+}
+
+/* Dropdown menu for the Edit button */
+.dropdownMenu {
+  @apply absolute top-full right-0 mt-2 w-40 bg-gray-900 rounded shadow-lg z-10;
+}


### PR DESCRIPTION
**Reference to Related Issue**


Fixes #37 
Fixes #54 
Fixes #61 

***Wont connect, will have to close menually***
Fixes [57](https://github.com/tabletop-generator/issues/issues/57)
Fixes [63](https://github.com/tabletop-generator/issues/issues/63)
Fixes [64](https://github.com/tabletop-generator/issues/issues/64)
Fixes [59](https://github.com/tabletop-generator/issues/issues/59)

**Proposed Changes**

- [ ] Changed the buttons is the asset card to correspond with the mock ups 
- [ ] Created UI for creating a collection and add assets to it (non functional as no APIs)
- [ ] Asset can be liked and unliked (Non functional - need to request API change)
- [ ] Asset url and collection can be copied by clicking on the share button
- [ ] Update button and delete were visually changed to correspond with mock ups 
- [ ] Delete asset warning message was changed based on mock ups 
- [ ] Added a "fake" placeholder message section 

**To Do**  
- [ ] Connect API calls  
- [ ] Separate CSS into its own file
- [ ] Create update collection UI (info: name/visibility/assess-remove) 
- [ ] Create delete collection warning message 